### PR TITLE
Fix invalid class name reference for Virtuoso

### DIFF
--- a/Store/Virtuoso/BasicUsage.php
+++ b/Store/Virtuoso/BasicUsage.php
@@ -12,6 +12,7 @@ use Saft\Rdf\StatementFactoryImpl;
 use Saft\Rdf\StatementIteratorFactoryImpl;
 use Saft\Sparql\Query\QueryFactoryImpl;
 use Saft\Sparql\Result\ResultFactoryImpl;
+use Saft\Addition\Virtuoso\Store\Virtuoso;
 
 /**
  * Configuration information about how to access Virtuoso.
@@ -23,7 +24,7 @@ $config = array(
 );
 
 // instantiate the store adapter which handles the communication with Virtuoso.
-$virtuoso = new Saft\Addition\Virtuoso\Store\Virtuoso(
+$virtuoso = new Virtuoso(
     new NodeFactoryImpl(),
     new StatementFactoryImpl(),
     new QueryFactoryImpl(),

--- a/Store/Virtuoso/SparqlQueryAndBasicDataManagement.php
+++ b/Store/Virtuoso/SparqlQueryAndBasicDataManagement.php
@@ -14,6 +14,7 @@ use Saft\Rdf\StatementImpl;
 use Saft\Rdf\StatementIteratorFactoryImpl;
 use Saft\Sparql\Query\QueryFactoryImpl;
 use Saft\Sparql\Result\ResultFactoryImpl;
+use Saft\Addition\Virtuoso\Store\Virtuoso;
 
 /**
  * Configuration information about how to access Virtuoso.
@@ -25,7 +26,7 @@ $config = array(
 );
 
 // instantiate the store adapter which handles the communication with Virtuoso.
-$virtuoso = new Saft\Addition\Virtuoso\Store\Virtuoso(
+$virtuoso = new Virtuoso(
     new NodeFactoryImpl(),
     new StatementFactoryImpl(),
     new QueryFactoryImpl(),


### PR DESCRIPTION
The Virtuoso store class needs to be either imported and referenced
with its local name or used with its full class name (with a leading
backslash).

This imports the Virtuoso store class via an explicit use statement and
instanciates the class with its local name in both example files.
